### PR TITLE
fixed username error with login credential

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -14,7 +14,7 @@ const loginUser = async (req, res) => {
     // create a token
     const token = createToken(user._id)
 
-    res.status(200).json({email, token})
+    res.status(200).json({email, token,name:user.name})
   } catch (error) {
     res.status(400).json({error: error.message})
   }


### PR DESCRIPTION
This PR addresses the issue where the user’s name only displays for new users (first-time signup). For returning users who log in with their credentials, the name field placeholder remains empty, as described in issue [#8](https://github.com/Rahul-sehrawat/chess-club-frontend/issues/8) of the frontend repository.